### PR TITLE
Update README with correct install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Go-written Changelog Generator. Create Changelogs based on GitHub pull request
 ## Installation
 
 ```
-go install k8c.io/gchl
+go install k8c.io/gchl@latest
 ```
 
 ## Usage


### PR DESCRIPTION
The install instructions are outdated, this doesn't work anymore:

```sh
$ go install k8c.io/gchl
go: 'go install' requires a version when current directory is not in a module
	Try 'go install k8c.io/gchl@latest' to install the latest version
```